### PR TITLE
Changed fsl-mender-setup.sh location

### DIFF
--- a/meta-mender-nxp-imx6ull/scripts/imx-4.9.88-2.0.0_demo_mender.xml
+++ b/meta-mender-nxp-imx6ull/scripts/imx-4.9.88-2.0.0_demo_mender.xml
@@ -4,10 +4,12 @@
   <include name="imx-4.9.88-2.0.0_ga.xml"/>
 
   <remote fetch="https://github.com/mendersoftware" name="mender"/>
-
   <project name="meta-mender" remote="mender" revision="rocko" path="sources/meta-mender"/>
-  <project name="meta-mender-community" remote="mender" revision="rocko" path="sources/meta-mender-community">
+
+  <!-- Remote repo to fetch the mender setup script -->
+  <remote fetch="https://github.com/brianleePTL" name="brian"/>
+  <project name="meta-mender-community" remote="brian" revision="rocko" path="sources/meta-mender-community">
     <linkfile src="meta-mender-nxp-imx6ull/scripts/fsl-setup-mender.sh" dest="fsl-setup-mender.sh"/>
-</project>
+  </project>
   
 </manifest>


### PR DESCRIPTION
`meta-mender-nxp-imx6ull` has been removed from `https://github.com/mendersoftware/meta-mender-community` hence changed the location to your own repo. i. e., `https://github.com/brianleePTL/meta-mender-community`